### PR TITLE
'SET' is deprecated, update to '='

### DIFF
--- a/Driver/SoundSystem.inc
+++ b/Driver/SoundSystem.inc
@@ -1,5 +1,5 @@
 IF !DEF(SOUNDSYSTEM_INC)
-SOUNDSYSTEM_INC	SET	1
+SOUNDSYSTEM_INC	=	1
 
 ;===============================
 ; Usage

--- a/Driver/SoundSystemNotes.inc
+++ b/Driver/SoundSystemNotes.inc
@@ -1,5 +1,5 @@
 IF !DEF(SOUNDSYSTEMNOTES_INC)
-SOUNDSYSTEMNOTES_INC	SET	1
+SOUNDSYSTEMNOTES_INC	=	1
 
 ;===============================
 ; Usage


### PR DESCRIPTION
In the latest version of RGBDS the SET keyword is deprecated, need to replace them with '='.